### PR TITLE
Update to TUNE Android SDK 5.1.1

### DIFF
--- a/TuneIntegration/build.gradle
+++ b/TuneIntegration/build.gradle
@@ -35,17 +35,17 @@ dependencies {
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
     }
 
-    testCompile 'com.segment.analytics.android:analytics-tests:4.0.0'
+    testCompile 'com.segment.analytics.android:analytics-tests:4.+'
 
     testCompile 'org.assertj:assertj-core:1.7.1'
 
     testCompile 'org.mockito:mockito-core:1.10.19'
 
-    testCompile 'org.powermock:powermock:1.6.2'
-    testCompile 'org.powermock:powermock-module-junit4:1.6.2'
-    testCompile 'org.powermock:powermock-module-junit4-rule:1.6.2'
-    testCompile 'org.powermock:powermock-api-mockito:1.6.2'
-    testCompile 'org.powermock:powermock-classloading-xstream:1.6.2'
+    testCompile 'org.powermock:powermock:1.6.5'
+    testCompile 'org.powermock:powermock-module-junit4:1.6.6'
+    testCompile 'org.powermock:powermock-module-junit4-rule:1.6.6'
+    testCompile 'org.powermock:powermock-api-mockito:1.6.6'
+    testCompile 'org.powermock:powermock-classloading-xstream:1.6.6'
 }
 
 apply from: 'https://raw.githubusercontent.com/blundell/release-android-library/master/android-release-aar.gradle'

--- a/TuneIntegration/build.gradle
+++ b/TuneIntegration/build.gradle
@@ -3,16 +3,16 @@ apply plugin: 'com.android.library'
 ext {
     PUBLISH_GROUP_ID = 'com.tune'
     PUBLISH_ARTIFACT_ID = 'tune-segment-integration'
-    PUBLISH_VERSION = '1.0.0'
+    PUBLISH_VERSION = '1.1.0'
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
-        minSdkVersion 9
-        targetSdkVersion 23
+        minSdkVersion 14
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
     }
@@ -25,9 +25,9 @@ android {
 }
 
 dependencies {
-    provided 'com.segment.analytics.android:analytics:4.0.0'
+    provided 'com.segment.analytics.android:analytics:4.+'
 
-    compile 'com.tune:tune-marketing-console-sdk:4.1.0'
+    compile 'com.tune:tune-marketing-console-sdk:5.1.1'
 
     testCompile 'junit:junit:4.12'
     testCompile('org.robolectric:robolectric:3.0') {

--- a/TuneIntegration/src/main/java/com/segment/analytics/android/integrations/tune/TuneIntegration.java
+++ b/TuneIntegration/src/main/java/com/segment/analytics/android/integrations/tune/TuneIntegration.java
@@ -2,6 +2,7 @@ package com.segment.analytics.android.integrations.tune;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.text.TextUtils;
 
 import com.segment.analytics.Analytics;
@@ -80,6 +81,17 @@ public class TuneIntegration extends Integration<Tune> {
         logger.verbose("TuneIntegration onActivityResumed: Calling TUNE measureSession");
         if (turnOnTMA) {
             TuneActivity.onResume(activity);
+        } else {
+            Intent intent = activity.getIntent();
+            if (Tune.getInstance() != null && intent != null) {
+                if (null != intent.getDataString()) {
+                    String uriString = intent.getDataString();
+                    Tune.getInstance().setReferralCallingPackage(activity.getCallingPackage());
+                    Tune.getInstance().setReferralUrl(uriString);
+                }
+
+                Tune.getInstance().measureSessionInternal();
+            }
         }
     }
 

--- a/TuneIntegration/src/main/java/com/segment/analytics/android/integrations/tune/TuneIntegration.java
+++ b/TuneIntegration/src/main/java/com/segment/analytics/android/integrations/tune/TuneIntegration.java
@@ -2,7 +2,6 @@ package com.segment.analytics.android.integrations.tune;
 
 import android.app.Activity;
 import android.content.Context;
-import android.content.Intent;
 import android.text.TextUtils;
 
 import com.segment.analytics.Analytics;
@@ -78,29 +77,14 @@ public class TuneIntegration extends Integration<Tune> {
 
     @Override
     public void onActivityResumed(Activity activity) {
-        logger.verbose("TuneIntegration onActivityResumed: Calling TUNE measureSession");
-        if (turnOnTMA) {
-            TuneActivity.onResume(activity);
-        } else {
-            Intent intent = activity.getIntent();
-            if (Tune.getInstance() != null && intent != null) {
-                if (null != intent.getDataString()) {
-                    String uriString = intent.getDataString();
-                    Tune.getInstance().setReferralCallingPackage(activity.getCallingPackage());
-                    Tune.getInstance().setReferralUrl(uriString);
-                }
-
-                Tune.getInstance().measureSessionInternal();
-            }
-        }
+        logger.verbose("TuneIntegration onActivityResumed");
+        TuneActivity.onResume(activity);
     }
 
     @Override
     public void onActivityPaused(Activity activity) {
         logger.verbose("TuneIntegration onActivityPaused");
-        if (turnOnTMA) {
-            TuneActivity.onPause(activity);
-        }
+        TuneActivity.onPause(activity);
     }
 
     // These are messages in the format of the Segment API.

--- a/TuneIntegration/src/main/java/com/segment/analytics/android/integrations/tune/TuneIntegration.java
+++ b/TuneIntegration/src/main/java/com/segment/analytics/android/integrations/tune/TuneIntegration.java
@@ -76,28 +76,18 @@ public class TuneIntegration extends Integration<Tune> {
     }
 
     @Override
-    public void onActivityStarted(Activity activity) {
-        logger.verbose("TuneIntegration onActivityStarted");
-        if (turnOnTMA) {
-            TuneActivity.onStart(activity);
-        }
-    }
-
-    @Override
     public void onActivityResumed(Activity activity) {
         logger.verbose("TuneIntegration onActivityResumed: Calling TUNE measureSession");
         if (turnOnTMA) {
             TuneActivity.onResume(activity);
         }
-        tune.setReferralSources(activity);
-        tune.measureSession();
     }
 
     @Override
-    public void onActivityStopped(Activity activity) {
-        logger.verbose("TuneIntegration onActivityStopped");
+    public void onActivityPaused(Activity activity) {
+        logger.verbose("TuneIntegration onActivityPaused");
         if (turnOnTMA) {
-            TuneActivity.onStop(activity);
+            TuneActivity.onPause(activity);
         }
     }
 

--- a/TuneIntegration/src/test/java/com/segment/analytics/android/integrations/tune/TuneTest.java
+++ b/TuneIntegration/src/test/java/com/segment/analytics/android/integrations/tune/TuneTest.java
@@ -101,22 +101,6 @@ public class TuneTest {
         assertThat(integration.tune).isNotNull();
     }
 
-    @Test public void activityStart() {
-        // Enable TMA to check for TuneActivity
-        ValueMap settings = new ValueMap().putValue("advertiserId", "advertiser_id")
-                .putValue("conversionKey", "conversion_key")
-                .putValue("turnOnTMA", true);
-
-        TuneIntegration integration =
-                (TuneIntegration) TuneIntegration.FACTORY.create(settings, analytics);
-
-        Activity activity = mock(Activity.class);
-        integration.onActivityStarted(activity);
-
-        verifyStatic();
-        TuneActivity.onStart(activity);
-    }
-
     @Test public void activityResume() {
         // Enable TMA to check for TuneActivity
         ValueMap settings = new ValueMap().putValue("advertiserId", "advertiser_id")
@@ -129,15 +113,14 @@ public class TuneTest {
         Activity activity = mock(Activity.class);
         integration.onActivityResumed(activity);
 
-        verify(tune).setReferralSources(activity);
-        verify(tune).measureSession();
         verifyNoMoreTuneInteractions();
 
         verifyStatic();
         TuneActivity.onResume(activity);
     }
 
-    @Test public void activityStop() {
+
+    @Test public void activityPause() {
         // Enable TMA to check for TuneActivity
         ValueMap settings = new ValueMap().putValue("advertiserId", "advertiser_id")
                 .putValue("conversionKey", "conversion_key")
@@ -147,9 +130,10 @@ public class TuneTest {
                 (TuneIntegration) TuneIntegration.FACTORY.create(settings, analytics);
 
         Activity activity = mock(Activity.class);
-        integration.onActivityStopped(activity);
+        integration.onActivityPaused(activity);
+
         verifyStatic();
-        TuneActivity.onStop(activity);
+        TuneActivity.onPause(activity);
     }
 
     @Test public void track() throws Exception {

--- a/TuneIntegration/src/test/java/com/segment/analytics/android/integrations/tune/TuneTest.java
+++ b/TuneIntegration/src/test/java/com/segment/analytics/android/integrations/tune/TuneTest.java
@@ -104,8 +104,7 @@ public class TuneTest {
     @Test public void activityResume() {
         // Enable TMA to check for TuneActivity
         ValueMap settings = new ValueMap().putValue("advertiserId", "advertiser_id")
-                .putValue("conversionKey", "conversion_key")
-                .putValue("turnOnTMA", true);
+                .putValue("conversionKey", "conversion_key");
 
         TuneIntegration integration =
                 (TuneIntegration) TuneIntegration.FACTORY.create(settings, analytics);
@@ -119,12 +118,10 @@ public class TuneTest {
         TuneActivity.onResume(activity);
     }
 
-
     @Test public void activityPause() {
         // Enable TMA to check for TuneActivity
         ValueMap settings = new ValueMap().putValue("advertiserId", "advertiser_id")
-                .putValue("conversionKey", "conversion_key")
-                .putValue("turnOnTMA", true);
+                .putValue("conversionKey", "conversion_key");
 
         TuneIntegration integration =
                 (TuneIntegration) TuneIntegration.FACTORY.create(settings, analytics);

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -15,6 +16,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Thu Mar 15 11:20:32 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Update the gradle dependency to use the 5.1.1 SDK.

As of 4.8.0, the TuneActivityLifecycleCallbacks implementation was added so `TuneActivity#onResume` and `TuneActivity#onPause` are applicable for AA and should always be called. `onResume` now handles calling `measureSession` so integration code was updated to reflect this.

`TuneActivity#onStart` and `TuneActivity#onStop` were deprecated and thus removed.

## Testing Instructions
Check out this branch, open the `TuneIntegration` project and run the tests in `TuneTest.java`.